### PR TITLE
0.4.1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,4 +28,4 @@ node_modules
 .lock-wscript
 
 # jsdoc dir
-.out
+.out/**

--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,6 @@ node_modules
 
 # Users Environment Variables
 .lock-wscript
+
+# jsdoc dir
+.out

--- a/Changelog.md
+++ b/Changelog.md
@@ -4,6 +4,8 @@
 * Added support for multi-session grep (allows for concurrency)
 * Cleaned up module.exports
 * Added token unit tests
+* Deprecated `sync()` and `async()` methods
+* Added jsdoc
 
 0.3.x
 ====

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ deep-grep
 Too many haystacks, not enough needles &mdash; or, "when you have a grep,
 everything looks like a list."
 
-```
+```javascript
 var needles = dg.deeply( [
 	foo, [
 		bar, baz, [
@@ -19,18 +19,8 @@ var needles = dg.deeply( [
 usage
 ====
 
-For simple grep:
+For grep on simple, flat (non-nested) lists:
 
-* `dg.sync()`
-  - `dg.sync( list, expression )` - evaluates `list`, returning a new list of every
-     element that matches `expression.test` (like `RegExp`).
-  - `dg.sync( list, func )` - same as above, only executes `func` for every element
-     of list, returning a new list.
-* `dg.async()`
-  - `dg.async( list, expression )` - same as with `sync()`, above, only
-     returns a promise to the list of matches.
-  - `dg.async( list, func, callback )` - same as `sync()`, above, except the
-     callback is called with a promise to the list of matches.
 * `dg.in()`
   - `dg.in( list, 'value' )` - returns `true` or `false` depending upon
      whether `list` contains `value`.
@@ -43,13 +33,9 @@ For simple grep:
   - `dg.flatten( nested_list )` - returns a list of all the lists contained in
     `nested_list`, concatenated into a single scope.
 
-For doing greppy things on nested structures:
+For doing greppy things on nested lists:
 
-For simple lists (that is, lists with nested lists of arbitrary depth but no
-complex datatypes &mdash; like objects &mdash; and no hashes), `dg.deeply` is
-invoked simply:
-
-```
+```javascript
 var haystack = [
 	'zebra', 'lion', [
 		'tiger', 'unicorn', 'emperor penguin'
@@ -65,7 +51,7 @@ var needles  = dg.deeply( list, function (t) {
 
 For more complex data, options are available to you:
 
-```
+```javascript
 var needles  = dg.deeply( arks['Noah'], function (t) { ... }, {
 	// Any of these may be defined
 	//
@@ -95,6 +81,20 @@ var needles  = dg.deeply( arks['Noah'], function (t) { ... }, {
 	'return-hash-tuples': true,
 } );
 ```
+
+deprecated methods
+====
+
+* `dg.sync()`
+  - `dg.sync( list, expression )` - evaluates `list`, returning a new list of every
+     element that matches `expression.test` (like `RegExp`).
+  - `dg.sync( list, func )` - same as above, only executes `func` for every element
+     of list, returning a new list.
+* `dg.async()`
+  - `dg.async( list, expression )` - same as with `sync()`, above, only
+     returns a promise to the list of matches.
+  - `dg.async( list, func, callback )` - same as `sync()`, above, except the
+     callback is called with a promise to the list of matches.
 
 author
 ====

--- a/lib/dg.js
+++ b/lib/dg.js
@@ -283,7 +283,7 @@ function list_in (list, test) { // {{{
 // It's not really super complicated but it is a nice idiom to have a shorthand
 // for.
 //
-function all_in ( list, test_list ) { // {{{
+function all_in (list, test_list) { // {{{
 	var results = [ ];
 	list.forEach( function (record) {
 		sync( test_list, function (t) { if (t == record) { return true } } )
@@ -291,6 +291,46 @@ function all_in ( list, test_list ) { // {{{
 	} );
 	return results;
 } // }}}
+
+/**
+ * @description Coalesce two objects into one
+ *
+ * @param {Object} from keys/values to read "from" into the coalesce
+ * @param {Object} to the "target" object to coalesce into
+ * @param {Object} parameters
+ * @param {Boolean} paramaters.return-clone return a cloned object rather than operating on 'to'
+ * @param {Array} paramaters.keys the list of keys to operate on (optional)
+ *
+ * @returns {Object} the coalesced object
+ *
+ * @example
+ *   var coalesced = dg.coalesce(
+ *     from, to,
+ *       {
+ *          keys: ['key1', 'key2'],
+ *          'return-clone': true
+ *       }
+ *    )
+ */
+function coalesce_object (from, to, parameters) {
+	var target;
+	if (parameters['return-clone']) {
+		target = to.slice(0);
+	}
+	else {
+		target = to;
+	}
+	if (parameters.keys && paramaters.keys.length) {
+		keys.forEach( function (key) {
+			clone[key] = from[key]
+		} )
+	}
+	else {
+		Object.keys( from ).forEach( function (key) {
+			clone[key] = from[key];
+		})
+	}
+}
 
 module.exports = {
 	'in'       : list_in, // 'in' is a reserved word, kids

--- a/lib/dg.js
+++ b/lib/dg.js
@@ -1,28 +1,47 @@
-// deep grep
-//
-//   if you're like me, you like data structures and you don't mind them
-//   being nested to various levels and of various types.
-//
-//   sometimes, though, when you want something deep in one of these
-//   structures, it can be a pain in the ass to ask it for:
-//
-//   var w = Object.keys( ds ).map( function (f) {
-//     return ds[f].forEach( function (elem) {
-//       return ds[f][elem].get_records( { matching: 'foo[^.]+.txt' } )
-//     } )
-//   } )
-//
-//   and similar sometimes you just want the things and you don't want to have
-//   to describe your data structure or nested object methods in excruciating
-//   detail to go and find them.
-//
-//   also i get sick of the amount of nested scoping node does, and this
-//   allows me to abstract some of that away into a lib.
-//
+/**
+ * @file deep grep
+ * @author Jane Arc <jane@cpan.org>
+ *
+ *  @overview if you're like me, you like data structures and you don't mind
+ *  them being nested to various levels and of various types.
+ *
+ *  sometimes, though, when you want something deep in one of these
+ *  structures, it can be a pain in the ass to ask it for something deeply-
+ *  nested.
+ *
+ *  sometimes you just want the things and you don't want to have
+ *  to describe your data structure or nested object methods in excruciating
+ *  detail to go and find them.
+ *
+ *  also i get sick of the amount of nested scoping node does, and this
+ *  allows me to abstract some of that away into a lib.
+ *
+ *  @example
+ *    var haystack = [ foo, [ bar, baz, [ bletch, [ qip ] ] ] ];
+ *    var needles  = dg.deeply( haystack, function (t) {
+ *      if (t == qip) { return true }
+ *    } );
+ */
 
 'use strict';
 
-function deeply ( deep, test, parameters, session ) { // {{{
+/**
+ * @description Perform a search through an arbitrarily-nested/complex data structure.
+ *
+ * @param {Array} deep the "target" list to search through; may be nested/contain complex data
+ * @param {Function|RegExp} test a function or regular expression to evaluate items in list
+ * @param {Object} parameters various configuration options for the operation
+ * @param {Boolean} parameters.check-object-methods evalute object method return values
+ * @param {Boolean} parameters.object-method-arguments parameters to pass object methods
+ * @param {Boolean} parameters.check-keys check object keys
+ * @param {Boolean} parameters.check-values check object values
+ * @param {Boolean} parameters.return-hash-tuples return tuples instead of keys or values
+ * @param {Boolean} parameters.return-promise return a promise to the results instead of a list.
+ * @param {Object} session for concurrency, a session object may be supplied
+ *
+ * @returns {Array|Promise} an promised array of objects with the requested fields/members.
+ */
+function deeply (deep, test, parameters, session) { // {{{
 	var xact;
 
 	// Attempt to discern whether we are running multiple deeply() sessions,
@@ -120,9 +139,14 @@ function deeply ( deep, test, parameters, session ) { // {{{
 	return g.results;
 } // }}}
 
-// Flatten the nested elements of a list into a single scope
-//
-function flatten ( list, behavior ) { // {{{
+/**
+ * @description Flatten the nested elements of a list into a single scope
+ *
+ * @param {Array} deep the "target" list to flatten; may be nested/contain complex data
+ *
+ * @returns {Array} a "flattened" array containing the elements in deep
+ */
+function flatten (list, behavior) { // {{{
 	var flat  = [ ]
 		, local = list;
 
@@ -143,8 +167,9 @@ function flatten ( list, behavior ) { // {{{
 		// and lists are assumed.
 		//
 
-		// this makes me feel so dirty:
-		//  Object.prototype.toString.call( f ).substr(8, 5)
+		// This is very suspicious but when I change it to typeof, it breaks, and
+		// I CBA to figure out what is wrong with it right now.
+		//
 		if ( Object.prototype.toString.call( element ).substr(8, 5) === 'Array' ) {
 			element.forEach( function (subelement) { local.push( subelement ) } );
 		}
@@ -157,9 +182,14 @@ function flatten ( list, behavior ) { // {{{
 
 } // }}}
 
-// Return the unique elements of a (optionally nested) list
-//
-function unique ( list ) { // {{{
+/**
+ * @description Return the unique elements of a (optionally nested) list
+ *
+ * @param {Array} deep the "target" list; may be nested/contain complex data
+ *
+ * @returns {Array} a list of the unique elements in deep
+ */
+function unique (list) { // {{{
 	var flist  = flatten( list )
 		, utable = { }
 	
@@ -170,7 +200,7 @@ function unique ( list ) { // {{{
 
 // Perform a synchronous (no-promise, blocking) grep
 //
-function sync ( list, expression ) { // {{{
+function sync (list, expression) { // {{{
 	var retval = [ ];
 	if ((typeof expression) == 'object') {
 		// Looks like they sent us an object. Verify it has test()
@@ -203,7 +233,7 @@ function sync ( list, expression ) { // {{{
 
 // Perform an asynchronous (promise, but probably still blocking) grep
 //
-function async ( list, expression, callback ) { // {{{
+function async (list, expression, callback) { // {{{
 	var q        = require('q')
 		, deferred = q.defer()
 		, retval   = [ ];
@@ -237,7 +267,7 @@ function async ( list, expression, callback ) { // {{{
 
 // Just figure out whether test exists in list
 //
-function list_in ( list, test ) { // {{{
+function list_in (list, test) { // {{{
 	var yes = false;
 
 	list.forEach( function (t) {

--- a/lib/dg.js
+++ b/lib/dg.js
@@ -40,6 +40,14 @@
  * @param {Object} session for concurrency, a session object may be supplied
  *
  * @returns {Array|Promise} an promised array of objects with the requested fields/members.
+ *
+ * @example
+ *   // finding a user in a big list of users
+ *   //
+ *   var user = dg.deeply( list_with_nested_hashes, function (t) {
+ *     if (t == username) { return true }
+ *   }, { 'return-hash-tuples': true, 'check-keys': true, 'check-values': false } )
+ *
  */
 function deeply (deep, test, parameters, session) { // {{{
 	var xact;
@@ -279,7 +287,7 @@ function list_in (list, test) { // {{{
 	return yes;
 } // }}}
 
-// Return all the values of List that are also in Test_List ('intersection')
+// Return all the values of list that are also in test_list ('intersection')
 // It's not really super complicated but it is a nice idiom to have a shorthand
 // for.
 //

--- a/lib/dg.js
+++ b/lib/dg.js
@@ -320,25 +320,26 @@ function all_in (list, test_list) { // {{{
  *       }
  *    )
  */
-function coalesce_object (from, to, parameters) {
+function coalesce_object (from, to, parameters) { // {{{
 	var target;
 	if (parameters['return-clone']) {
-		target = to.slice(0);
+		target = clone( to );
 	}
 	else {
 		target = to;
 	}
-	if (parameters.keys && paramaters.keys.length) {
-		keys.forEach( function (key) {
-			clone[key] = from[key]
+	if (parameters.keys && parameters.keys.length) {
+		parameters.keys.forEach( function (key) {
+			target[key] = from[key]
 		} )
 	}
 	else {
 		Object.keys( from ).forEach( function (key) {
-			clone[key] = from[key];
+			target[key] = from[key];
 		})
 	}
-}
+	return target;
+} // }}}
 
 module.exports = {
 	'in'       : list_in, // 'in' is a reserved word, kids
@@ -347,7 +348,10 @@ module.exports = {
 	'sync'     : sync,
 	'deeply'   : deeply,
 	'unique'   : unique,
-	'flatten'  : flatten
+	'flatten'  : flatten,
+
+	'coalesce'        : coalesce_object,
+	'coalesce_object' : coalesce_object
 }
 
 
@@ -364,6 +368,27 @@ function arrayhandler (a, xact) { // {{{
 		a.forEach( function (subelement) { heap.sessions[ xact.serial ].deep.push( subelement ) } );
 		return true;
 	}
+} // }}}
+
+// This is stolen/paraphrased from io.js
+//
+function extend (origin, add) { // {{{
+	// Don't do anything if add isn't an object
+	//
+	if (!add || (typeof add != 'object')) {
+		return origin;
+	}
+
+	Object.keys( add ).forEach( function (key) {
+		origin[key] = add[key]
+	} );
+	return origin;
+} // }}}
+
+// Sugar on top of extend for clones
+//
+function clone (thing) { // {{{
+	return extend( {}, thing );
 } // }}}
 
 function testwrapper (thing, target) { // {{{

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "mocha": "*",
     "chai": "*",
     "q": "*",
-    "xact-id-tiny": ">=0.0.4",
+    "xact-id-tiny": ">=0.0.6",
     "log4js": "*"
   },
   "homepage": "https://github.com/janearc/deep-grep"

--- a/test/20-coalese-object.js
+++ b/test/20-coalese-object.js
@@ -25,7 +25,7 @@ it( 'coalesce', function () {
 	var merged = {
 		foo: 'foo_value',
 		bar: 'bar_value',
-		baz: 'baz_value'
+		baz: 'baz_value',
 		qip: 'qip_value',
 		quux: 'quux_value'
 	}

--- a/test/20-coalese-object.js
+++ b/test/20-coalese-object.js
@@ -1,0 +1,34 @@
+var start = function () { return {
+	foo: 'foo_value',
+	bar: 'bar_value',
+	baz: 'baz_value'
+} }
+
+var into = function () { return {
+	qip: 'qip_value',
+	quux: 'quux_value'
+} };
+
+var assert   = require( 'assert' )
+	, chai     = require( 'chai' )
+	, dg       = require( '../lib/dg.js' )
+
+it( 'syntax', function () {
+	assert( function () { return dg = require( '../lib/dg.js' ) }, 'require' );
+} );
+
+it( 'coalesce', function () {
+	var new_obj = dg.coalesce_object( start(), into(), {
+		'keys':         [ 'foo', 'bar', 'baz' ],
+		'return-clone': true
+	} );
+	var merged = {
+		foo: 'foo_value',
+		bar: 'bar_value',
+		baz: 'baz_value'
+		qip: 'qip_value',
+		quux: 'quux_value'
+	}
+	assert( new_obj, 'truthy return' );
+	assert.deepEqual( new_obj, merged, 'coalesced object' );
+} );


### PR DESCRIPTION
* rolls in functionality needed in [sendak #87](https://github.com/18F/Sendak/issues/87)
* adds extensive javadoc
* cleans up readme
* deprecates `sync()` and `async()` calls (these will be handled by `deeply` with invocation options in the future)